### PR TITLE
Remove use of Twilio AuthToken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Project files
 src/packages/
 
+# Config 
+./Source/Virgil.TwilioIPMessaging/Web.config
+
 
 # User-specific files
 *.suo

--- a/README.md
+++ b/README.md
@@ -14,13 +14,19 @@ There are only two steps required to publish Virgil History Service :)
 
 ## Configuration
 
+```
+$ cd Source/Virgil.TwilioIPMessaging
+$ cp sample.web.config web.config
+```
+
 Set Twilio & Virgil authentication tokens in web.config
 
 ```
   <appSettings>
     ...
     <add key="twilio:AccountSID" value="{TWILIO_ACCOUNT_SID}" />
-    <add key="twilio:AuthToken" value="{TWILIO_AUTH_TOKEN}" />
+    <add key="twilio:ApiKey" value="{TWILIO_API_KEY}" />
+    <add key="twilio:ApiKeySecret" value="{TWILIO_API_KEY_SECRET}" />
     <add key="twilio:IpMessagingServiceSID" value="{TWILIO_IP_MESSAGING_SERVICE_SID}" />
     <add key="virgil:AppToken" value="{VIRGIL_SECURITY_ACCESS_TOKEN}" />
     ...

--- a/Source/Virgil.TwilioIPMessaging/Common/Constants.cs
+++ b/Source/Virgil.TwilioIPMessaging/Common/Constants.cs
@@ -6,7 +6,6 @@
     public class Constants
     {
         public static string TwilioAccountSID => ConfigurationManager.AppSettings["twilio:AccountSID"];
-        public static string TwilioAuthToken => ConfigurationManager.AppSettings["twilio:AuthToken"];
         public static string TwilioApiKey => ConfigurationManager.AppSettings["twilio:ApiKey"];
         public static string TwilioApiKeySecret => ConfigurationManager.AppSettings["twilio:ApiKeySecret"];
 #if !DEBUG

--- a/Source/Virgil.TwilioIPMessaging/Common/TwilioService.cs
+++ b/Source/Virgil.TwilioIPMessaging/Common/TwilioService.cs
@@ -25,7 +25,7 @@
         private WebClient GetWebClient()
         {
             var webClient = new WebClient();
-            var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(Constants.TwilioAccountSID + ":" + Constants.TwilioAuthToken));
+            var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(Constants.TwilioApiKey + ":" + Constants.TwilioApiKeySecret));
             webClient.Headers[HttpRequestHeader.Authorization] = "Basic " + credentials;
 
             return webClient;

--- a/Source/Virgil.TwilioIPMessaging/sample.Web.config
+++ b/Source/Virgil.TwilioIPMessaging/sample.Web.config
@@ -9,13 +9,12 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="twilio:AccountSID" value="ACc205ae93727bab431c82041a19386001" />
-    <add key="twilio:AuthToken" value="1f607285b647ceafda476d7979fa0587" />
-    <add key="twilio:ApiKey" value="SK40ffbc56611f4fb61dde3456abfc8a1b" />
-    <add key="twilio:ApiKeySecret" value="4vjo6yXUOeWLuJi0rZSb8hHTvPhJwCAr" />
-    <add key="twilio:IpMessagingServiceSID" value="ISf3bba66dcca1477a88668aa7bf200554" />
-    <add key="twilio:IpMessagingServiceSIDTest" value="IS7a8fb2bde06645a89e67049410451ce4" />
-    <add key="virgil:AppToken" value="eyJpZCI6IjYzZWUyYWRiLWI4YzQtNDEyMC04NDc2LTM5NGY3ZjUzYjg4ZCIsImFwcGxpY2F0aW9uX2NhcmRfaWQiOiIxMmQxNzkwNy00YjdiLTQ0YTctODRkMS1hZjA4NTc5MjhiOWQiLCJ0dGwiOi0xLCJjdGwiOi0xLCJwcm9sb25nIjowfQ==.MIGaMA0GCWCGSAFlAwQCAgUABIGIMIGFAkAXw3S9XDbJAOM64FFi3tGlSUCnOSPDgEqzuZmfOd2Pyu+zIE91Dr1kXqndLsSO3UOrjIBSmgmOGK7DpuLhUM8nAkEAgg1r9DqiEB4BKA2qD+9R7mwg8Y7ZARyzUIvFzhBeT/wWPjOpi8LYpgwXBRf/32Fr2a5xQD1j11buxnvNT+CX+w==" />
+    <add key="twilio:AccountSID" value="" />
+    <add key="twilio:ApiKey" value="" />
+    <add key="twilio:ApiKeySecret" value="" />
+    <add key="twilio:IpMessagingServiceSID" value="" />
+    <add key="twilio:IpMessagingServiceSIDTest" value="" />
+    <add key="virgil:AppToken" value="" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5.2" />


### PR DESCRIPTION
The most secure way to use Twilio auth is with API Keys rather than AuthToken. API keys are easier to revoke and cycle.
https://www.twilio.com/docs/api/rest/request

Also removed keys from code. 
